### PR TITLE
adds more filters to the widget configuration and adds time related data in open_tickets tables

### DIFF
--- a/widgets/open-tickets/configs.xml
+++ b/widgets/open-tickets/configs.xml
@@ -4,7 +4,7 @@
   <email>contact@centreon.com</email>
   <website>http://www.centreon.com</website>
   <description>Widget for opening tickets</description>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <keywords>centreon, widget, tickets</keywords>
   <screenshot></screenshot>
   <thumbnail>./widgets/open-tickets/resources/centreon-logo.png</thumbnail>
@@ -20,8 +20,10 @@
     <preference label="Display Warning" name="svc_warning" defaultValue="1" type="boolean"/>
     <preference label="Display Critical" name="svc_critical" defaultValue="1" type="boolean"/>
     <preference label="Display Unknown" name="svc_unknown" defaultValue="1" type="boolean"/>
+    <preference label="Hide host with disabled notifications" name="h_disabled_notif" defaultValue="0" type="boolean"/>
+    <preference label="Hide service with disabled notifications" name="s_disabled_notif" defaultValue="0" type="boolean"/>
     <preference label="Criticities Filters (criticities name separated by ',')" name="criticality_filter" defaultValue="" type="text"/>
-    <preference label="Acknowledgement Filter" name="acknowledgement_filter" defaultValue="all" type="list">
+    <preference label="Acknowledgement Filter" name="acknowledgement_filter" defaultValue="all" type="list">  
       <option value="ack" label="Acknowledged"/>
       <option value="nack" label="Not Acknowleged"/>
     </preference>

--- a/widgets/open-tickets/src/index.php
+++ b/widgets/open-tickets/src/index.php
@@ -212,6 +212,14 @@ if (isset($preferences['hide_down_host']) && $preferences['hide_down_host']) {
 if (isset($preferences['hide_unreachable_host']) && $preferences['hide_unreachable_host']) {
     $query = CentreonUtils::conditionBuilder($query, " h.state != 2 ");}
 
+if (isset($preferences['h_disabled_notif']) && $preferences['h_disabled_notif']) {
+        $query = CentreonUtils::conditionBuilder($query, " h.notify != 0 ");
+}
+
+if (isset($preferences['s_disabled_notif']) && $preferences['s_disabled_notif']) {
+        $query = CentreonUtils::conditionBuilder($query, " s.notify != 0 ");
+}
+
 # For Open Tickets
 if (!isset($preferences['opened_tickets']) || $preferences['opened_tickets'] == 0) {
     $query .= " AND mop1.timestamp IS NULL ";

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -1096,12 +1096,12 @@ Output: {$service.output|substr:0:1024}
             }
 
             foreach ($extra_args['host_problems'] as $row) {
-                $db_storage->query("INSERT INTO mod_open_tickets_link (`ticket_id`, `host_id`, `host_state`, `hostname`) VALUES
-    ('" . $db_storage->escape($result['ticket_id']) . "', '" . $db_storage->escape($row['host_id']) . "', '" . $db_storage->escape($row['host_state']) . "', '" . $db_storage->escape($row['name']) . "')");
+                $db_storage->query("INSERT INTO mod_open_tickets_link (`ticket_id`, `host_id`, `host_state`, `hostname`, `last_hard_state_change`) VALUES
+    ('" . $db_storage->escape($result['ticket_id']) . "', '" . $db_storage->escape($row['host_id']) . "', '" . $db_storage->escape($row['host_state']) . "', '" . $db_storage->escape($row['name']) . "', '" . $db_storage->escape($row['last_hard_state_change']) . "')");
             }
             foreach ($extra_args['service_problems'] as $row) {
-                $db_storage->query("INSERT INTO mod_open_tickets_link (`ticket_id`, `host_id`, `host_state`, `hostname`, `service_id`, `service_state`, `service_description`) VALUES
-    ('" . $db_storage->escape($result['ticket_id']) . "', '" . $db_storage->escape($row['host_id']) . "', '" . $db_storage->escape($row['host_state']) . "', '" . $db_storage->escape($row['host_name']) . "', '" . $db_storage->escape($row['service_id']) . "', '" . $db_storage->escape($row['service_state']) . "', '" . $db_storage->escape($row['description']) . "')");
+                $db_storage->query("INSERT INTO mod_open_tickets_link (`ticket_id`, `host_id`, `host_state`, `hostname`, `service_id`, `service_state`, `service_description`, `last_hard_state_change`) VALUES
+    ('" . $db_storage->escape($result['ticket_id']) . "', '" . $db_storage->escape($row['host_id']) . "', '" . $db_storage->escape($row['host_state']) . "', '" . $db_storage->escape($row['host_name']) . "', '" . $db_storage->escape($row['service_id']) . "', '" . $db_storage->escape($row['service_state']) . "', '" . $db_storage->escape($row['description']) . "', '" . $db_storage->escape($row['last_hard_state_change']) . "')");
             }
 
             if (!is_null($extra_args['data_type']) && !is_null($extra_args['data'])) {

--- a/www/modules/centreon-open-tickets/sql/install.sql
+++ b/www/modules/centreon-open-tickets/sql/install.sql
@@ -85,7 +85,8 @@ CREATE TABLE IF NOT EXISTS centreon_storage.`mod_open_tickets_link` (
     `host_state` int(11),
     `service_state` int(11),
     `hostname` VARCHAR(1024),
-    `service_description` VARCHAR(1024) DEFAULT NULL
+    `service_description` VARCHAR(1024) DEFAULT NULL,
+    `last_hard_state_change` INT(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE centreon_storage.`mod_open_tickets_link`


### PR DESCRIPTION
Allows people to filter on the view in the widget based on the notification state of the service or the host

Allows people to easily get access to the ticket creation time and the last hard state change time of the service or the host when creating the ticket in order to get a few statistics related to the reaction time. 

i'm not sure about the update process with the sql file, i've edited it for a fresh installation but what about an update ? 