### PR TITLE
fix(config): load smarty function in Mail provider

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Mail/MailProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Mail/MailProvider.class.php
@@ -64,7 +64,7 @@ class MailProvider extends AbstractProvider {
      * @return void
      */
     protected function _getConfigContainer1Extra() {
-        $tpl = new Smarty();
+        $tpl = $this->initSmartyTemplate();
         $tpl = initSmartyTplForPopup($this->_centreon_open_tickets_path, $tpl, 'providers/Mail/templates', $this->_centreon_path);
         
         $tpl->assign("centreon_open_tickets_path", $this->_centreon_open_tickets_path);
@@ -139,7 +139,7 @@ class MailProvider extends AbstractProvider {
             return $result;
         }
         
-        $tpl = new Smarty();
+        $tpl = $this->initSmartyTemplate();
         $tpl = initSmartyTplForPopup($this->_centreon_open_tickets_path, $tpl, 'providers/Abstract/templates', $this->_centreon_path);
         
         $tpl->assign("centreon_open_tickets_path", $this->_centreon_open_tickets_path);


### PR DESCRIPTION
Load smarty extended function in Mail providers by executing initSmartyTemplate() function.

ref: #53