### PR TITLE
New duration filter

### DIFF
--- a/widgets/open-tickets/configs.xml
+++ b/widgets/open-tickets/configs.xml
@@ -20,6 +20,7 @@
     <preference label="Display Warning" name="svc_warning" defaultValue="1" type="boolean"/>
     <preference label="Display Critical" name="svc_critical" defaultValue="1" type="boolean"/>
     <preference label="Display Unknown" name="svc_unknown" defaultValue="1" type="boolean"/>
+    <preference label="Duration Filter (seconds)" name="duration_filter" defaultValue="" type="compare"/>
     <preference label="Criticities Filters (criticities name separated by ',')" name="criticality_filter" defaultValue="" type="text"/>
     <preference label="Acknowledgement Filter" name="acknowledgement_filter" defaultValue="all" type="list">
       <option value="ack" label="Acknowledged"/>

--- a/widgets/open-tickets/src/index.php
+++ b/widgets/open-tickets/src/index.php
@@ -228,6 +228,24 @@ if (isset($preferences['svc_unknown']) && $preferences['svc_unknown']) {
 if (count($stateTab)) {
     $query = CentreonUtils::conditionBuilder($query, " s.state IN (" . implode(',', $stateTab) . ")");
 }
+
+if (isset($preferences['duration_filter']) && $preferences['duration_filter'] != "") {
+    $tab = split(" ", $preferences['duration_filter']);
+    $op = $tab[0];
+    //For results to be correct we have to rotate operands
+    if($op === 'gt') $op = 'lt';
+    else if($op == 'lt') $op = 'gt';
+    else if($op == 'gte') $op = 'lte';
+    else if($op == 'lte') $op = 'gte';
+    if (isset($tab[1])) {
+        $search = $tab[1];
+        $search = time() - $search;
+    }
+    if ($op && isset($search) && $search != "") {
+        $query = CentreonUtils::conditionBuilder($query, "s.last_state_change ".CentreonUtils::operandToMysqlFormat($op)." '".$dbb->escape($search)."' ");
+    }
+}
+
 if (isset($preferences['hide_down_host']) && $preferences['hide_down_host']) {
     $query = CentreonUtils::conditionBuilder($query, " h.state != 1 ");
 }


### PR DESCRIPTION
Add a new parameter filter.
This parameter controls the elapsed time, in seconds, since the alarm has been triggered until it appears in the view.
Many times there are contingency plans for the automatic recovery of some kind of alarms. This parameter prevents the alarm from being displayed in the view, if the alarm is recovered after a few seconds.