### PR TITLE
Adds placeholder mapping for custom lists

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -891,6 +891,7 @@ Output: {$service.output|substr:0:1024}
 
                 $id = '-1';
                 $value = '';
+                $placeholder = '';
                 $matches = array();
                 if (preg_match('/^(.*?)___(.*?)___(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
                     $id = $matches[1];
@@ -900,7 +901,7 @@ Output: {$service.output|substr:0:1024}
                     $id = $matches[1];
                     $value = $matches[2];
                 }
-                if (!empty($placeholder) && isset($placeholder)) {
+                if (!empty($placeholder)) {
                     $select_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'value' => $value, 'placeholder' => $placeholder);
                 } else {
                     $select_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'value' => $value);

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -892,12 +892,19 @@ Output: {$service.output|substr:0:1024}
                 $id = '-1';
                 $value = '';
                 $matches = array();
-                if (preg_match('/^(.*?)_(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
+                if (preg_match('/^(.*?)___(.*?)___(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
+                    $id = $matches[1];
+                    $value = $matches[2];
+                    $placeholder = $matches[3];
+                } elseif (preg_match('/^(.*?)_(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
                     $id = $matches[1];
                     $value = $matches[2];
                 }
-
-                $select_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'value' => $value);
+                if (!empty($placeholder) && isset($placeholder)) {
+                    $select_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'value' => $value, 'placeholder' => $placeholder);
+                } else {
+                    $select_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'value' => $value);
+                }
                 if (method_exists($this, $method_name)) {
                     $more_attributes = $this->{$method_name}($values['Id'], $id);
                     $select_lists[$values['Id']] = array_merge($select_lists[$values['Id']], $more_attributes);

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -897,7 +897,7 @@ Output: {$service.output|substr:0:1024}
                     $id = $matches[1];
                     $value = $matches[2];
                     $placeholder = $matches[3];
-                } elseif (preg_match('/^(.*?)_(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
+                } elseif (preg_match('/^(.*?)___(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
                     $id = $matches[1];
                     $value = $matches[2];
                 }

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -925,8 +925,13 @@ Output: {$service.output|substr:0:1024}
 
                 $id = '-1';
                 $value = '';
+                $placeholder = '';
                 $matches = array();
-                if (preg_match('/^(.*?)_(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
+                if (preg_match('/^(.*?)___(.*?)___(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
+                    $id = $matches[1];
+                    $value = $matches[2];
+                    $placeholder = $matches[3];
+                } elseif (preg_match('/^(.*?)___(.*)$/', $this->_submitted_config['select_' . $values['Id']], $matches)) {
                     $id = $matches[1];
                     $value = $matches[2];
                 }
@@ -943,7 +948,11 @@ Output: {$service.output|substr:0:1024}
 
                 $tpl->assign('string', $value_body);
                 $content = $tpl->fetch('eval.ihtml');
-                $body_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'name' => $value, 'value' => $content);
+                if (!empty($placeholder)) {
+                    $body_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'name' => $value, 'value' => $content, 'placeholder' => $placeholder);
+                } else {
+                    $body_lists[$values['Id']] = array('label' => _($values['Label']), 'id' => $id, 'name' => $value, 'value' => $content);
+                }
             }
         }
 

--- a/www/modules/centreon-open-tickets/providers/Abstract/templates/display_selected_lists.ihtml
+++ b/www/modules/centreon-open-tickets/providers/Abstract/templates/display_selected_lists.ihtml
@@ -1,5 +1,9 @@
 {foreach from=$select item=v}
 {if $v.id ne "-1"}
-{$v.label}: {$v.value}{$separator}
+    {if $v.placeholder != ""}
+        {$v.label}: {$v.placeholder} - {$v.value}{$separator}
+    {else}
+        {$v.label}: {$v.value}{$separator}
+    {/if}
 {/if}
 {/foreach}

--- a/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
+++ b/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
@@ -8,9 +8,9 @@
         <option value="-1"> -- select -- </option>
         {foreach from=$groups.$groupId.values key=k item=v}
         {if $groups.$groupId.placeholder.$k != ""}
-            <option value='{$k}_{$v}' {if $v eq $groups.$groupId.default}selected{/if}>{$groups.$groupId.placeholder.$k}</option>
+            <option value='{$k}___{$v}___{$groups.$groupId.placeholder.$k}' {if $v eq $groups.$groupId.default}selected{/if}>{$groups.$groupId.placeholder.$k}</option>
         {else}
-            <option value='{$k}_{$v}' {if $v eq $groups.$groupId.default}selected{/if}>{$v}</option>
+            <option value='{$k}___{$v}' {if $v eq $groups.$groupId.default}selected{/if}>{$v}</option>
         {/if}
         {/foreach}
         </select>


### PR DESCRIPTION
- you can now use {$select.<custom_list_label>.placeholder} to get the value of the custom list placeholder

Since we use "_" as a separator, and this is a quite common character, i've changed it to match three consecutive _ 