### PR TITLE
chore(ci): use discoverGitReferenceBuild instead of reference build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,12 +63,12 @@ try {
           ])
         }
 
+        discoverGitReferenceBuild()
         recordIssues(
           enabledForFailure: true,
           qualityGates: [[threshold: 1, type: 'DELTA', unstable: false]],
           tool: phpCodeSniffer(id: 'phpcs', name: 'phpcs', pattern: 'codestyle-be.xml'),
-          trendChartType: 'NONE',
-          referenceJobName: 'centreon-open-tickets/master'
+          trendChartType: 'NONE'
         )
 
         if ((env.BUILD == 'RELEASE') || (env.BUILD == 'REFERENCE')) {


### PR DESCRIPTION
## Description

use discoverGitReferenceBuild instead of manually set reference build
this is needed by new warning ng plugin version

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check CI