### PR TITLE
jquery 3.5 compatibility fix  widget + ticket log

### DIFF
--- a/widgets/open-tickets/data.js
+++ b/widgets/open-tickets/data.js
@@ -37,14 +37,14 @@ function loadToolBar()
 jQuery(function () {
   loadToolBar();
   loadPage();
-  $('.checkall').live('click', function () {
+  $(document).on('click', ".checkall", function () {
     var chck = this.checked;
     $(this).parents().find(':checkbox').each(function () {
       $(this).attr('checked', chck);
       clickedCb[$(this).attr('id')] = chck;
     });
   });
-  $(".selection").live('click', function () {
+  $(document).on('click', ".selection", function () {
     clickedCb[$(this).attr('id')] = this.checked;
   });
 });

--- a/www/modules/centreon-open-tickets/lib/commonFunc.js
+++ b/www/modules/centreon-open-tickets/lib/commonFunc.js
@@ -5,11 +5,11 @@ function call_ajax_sync(data, call_ok_func, path_call) {
 
     jQuery.ajaxSetup({async:false});
     jQuery.post(path_call, {data: dataString}, call_ok_func)
-    .success(function() { jQuery("body").css("cursor", "auto"); })
-    .error(function() {
+    .done(function() { jQuery("body").css("cursor", "auto"); })
+    .fail(function() {
         jQuery("body").css("cursor", "auto");
     })
-    .complete(function() { jQuery("body").css("cursor", "auto"); });
+    .always(function() { jQuery("body").css("cursor", "auto"); });
     jQuery.ajaxSetup({async:true});
 }
 
@@ -19,9 +19,9 @@ function call_ajax_async(data, call_ok_func, path_call) {
 
     jQuery.ajaxSetup({async:true});
     jQuery.post(path_call, {data: dataString}, call_ok_func)
-    .success(function() { jQuery("body").css("cursor", "auto"); })
-    .error(function() {
+    .done(function() { jQuery("body").css("cursor", "auto"); })
+    .fail(function() {
         jQuery("body").css("cursor", "auto");
     })
-    .complete(function() { jQuery("body").css("cursor", "auto"); });
+    .always(function() { jQuery("body").css("cursor", "auto"); });
 }


### PR DESCRIPTION
Fix the following issues with jQuery 3.5:

in the open ticket widget, ticking a checkbox isn't doing anything 

in the event logs -> ticket log, clicking the "apply period" button breaks the page