### PR TITLE
use human ticket id instead of internal id

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Jira/JiraProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Jira/JiraProvider.class.php
@@ -473,7 +473,7 @@ class JiraProvider extends AbstractProvider
                 'contact' => $contact,
                 'host_problems' => $host_problems,
                 'service_problems' => $service_problems,
-                'ticket_value' => $this->_jira_call_response['id'],
+                'ticket_value' => $this->_jira_call_response['key'],
                 'subject' => $ticket_arguments[$this->_internal_arg_name[self::ARG_SUMMARY]],
                 'data_type' => self::DATA_TYPE_JSON,
                 'data' => json_encode(


### PR DESCRIPTION
This provider doesn't have the possibility to close the ticket in Jira, it is therefore useless to use the internal ticket id instead of the human readable ticket id. 

And it is also possible to have an url that is using the key to get redirected  to the ticket in Jira
(https://xxxxx.atlassian.net/browse/{$ticket_id} where ticket_id is XXX-123)

it may also be confusing to use the id instead of the key because if key is XXX-123, the id might be 10122 which is confusing for the users (might have something to do with the internal id starting at 0 and the ticket id for user starting at 1)