### PR TITLE
use genopt for ticket ack

### DIFF
--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -19,6 +19,10 @@
  * limitations under the License.
  */
 
+require_once $centreon_path . 'www/class/centreon.class.php';
+
+global $centreon;
+
 function get_contact_information()
 {
     global $db, $centreon_bg;
@@ -183,6 +187,24 @@ try {
             $method_external_name = 'setProcessCommand';
         }
 
+        if (isset($centreon->optGen['monitoring_ack_sticky']) && $centreon->optGen['monitoring_ack_sticky']) {
+            $sticky = 2;
+        } else {
+            $sticky =1;
+        }
+
+        if (isset($centreon->optGen['monitoring_ack_notify']) && $centreon->optGen['monitoring_ack_notify']) {
+            $notify = 1;
+        } else {
+            $notify =0;
+        }
+
+        if (isset($centreon->optGen['monitoring_ack_persistent']) && $centreon->optGen['monitoring_ack_persistent']) {
+            $persistent = 1;
+        } else {
+            $persistent =0;
+        }
+
         foreach ($selected['host_selected'] as $value) {
             $command = "CHANGE_CUSTOM_HOST_VAR;%s;%s;%s";
             call_user_func_array(
@@ -205,9 +227,9 @@ try {
                         sprintf(
                             $command,
                             $value['name'],
-                            2,
-                            0,
-                            1,
+                            $sticky,
+                            $notify,
+                            $persistent,
                             $contact_infos['alias'],
                             'open ticket: ' . $resultat['result']['ticket_id']
                         ),
@@ -240,9 +262,9 @@ try {
                             $command,
                             $value['host_name'],
                             $value['description'],
-                            2,
-                            0,
-                            1,
+                            $sticky,
+                            $notify,
+                            $persistent,
                             $contact_infos['alias'],
                             'open ticket: ' . $resultat['result']['ticket_id']
                         ),

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -190,19 +190,19 @@ try {
         if (isset($centreon->optGen['monitoring_ack_sticky']) && $centreon->optGen['monitoring_ack_sticky']) {
             $sticky = 2;
         } else {
-            $sticky =1;
+            $sticky = 1;
         }
 
         if (isset($centreon->optGen['monitoring_ack_notify']) && $centreon->optGen['monitoring_ack_notify']) {
             $notify = 1;
         } else {
-            $notify =0;
+            $notify = 0;
         }
 
         if (isset($centreon->optGen['monitoring_ack_persistent']) && $centreon->optGen['monitoring_ack_persistent']) {
             $persistent = 1;
         } else {
-            $persistent =0;
+            $persistent = 0;
         }
 
         foreach ($selected['host_selected'] as $value) {


### PR DESCRIPTION
- [x] 19.10
- [x] 20.04
- [x] 20.10
- [x] 21.04
- [x] master

when opening a ticket, you have the possibility to create an ack. By default it is forced to sticky, no notification and persistent. Instead of using this, we should use the parameters that are set in administration -> monitoring