### PR TITLE
improve easyvista error management

### DIFF
--- a/www/modules/centreon-open-tickets/providers/EasyvistaSoap/EasyvistaSoapProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/EasyvistaSoap/EasyvistaSoapProvider.class.php
@@ -525,7 +525,7 @@ class EasyvistaSoapProvider extends AbstractProvider
         
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
-        
+
         if ($httpCode != 200) {
             $this->setWsError($this->soap_result);
             return 1;

--- a/www/modules/centreon-open-tickets/providers/EasyvistaSoap/EasyvistaSoapProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/EasyvistaSoap/EasyvistaSoapProvider.class.php
@@ -522,8 +522,14 @@ class EasyvistaSoapProvider extends AbstractProvider
             curl_close($ch);
             return 1;
         }
-
+        
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
+        
+        if ($httpCode != 200) {
+            $this->setWsError($this->soap_result);
+            return 1;
+        }
 
         return 0;
     }


### PR DESCRIPTION
when easyvista can't open a ticket, it returns a huge error message (most of the time with the sql query that failed on its side). Because we do not check if http code is 200, we try to put the error message in our mod open ticket databases as a ticket ID. And we don't display the error message to people so they don't know what happened to their ticket