### PR TITLE
enh(provider): preselect if only 1 choice in list selection

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
+++ b/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
@@ -10,7 +10,9 @@
             {assign var="group" value=$sortgroup_result}
         {/if}
         <select id="select_{$groupId}" name="select_{$groupId}">
-        <option value="-1"> -- select -- </option>
+        {if $group|@count != 1}
+            <option value="-1"> -- select -- </option>
+        {/if}
         {foreach from=$group key=k item=v}
         {if $groups.$groupId.placeholder.$k != ""}
             <option value='{$k}___{$v}___{$groups.$groupId.placeholder.$k}' {if $v eq $groups.$groupId.default}selected{/if}>{$groups.$groupId.placeholder.$k}</option>


### PR DESCRIPTION
## Description

If you have only 1 choice in list selection (popup before opening a ticket), the only choice is selected by default.
Example:
![image](https://user-images.githubusercontent.com/9079781/158595977-52955141-13e2-40b5-a10f-821b9817b2a9.png)


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

You can create a mail provider with a custom list with only one entry:
![image](https://user-images.githubusercontent.com/9079781/158596156-ec766706-d02e-408c-917b-423ed382885a.png)


## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
