### PR TITLE
enh(acknowledgement): use default options

### DIFF
--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -96,14 +96,13 @@ if (isset($get_information['form']['persistent'])) {
     $persistent = 1;
 }
 if (isset($get_information['form']['sticky'])) {
-    $sticky = 1;
+    $sticky = 2;
 }
 if (isset($get_information['form']['notify'])) {
     $notify = 1;
 }
 
 try {
-    #fwrite($fp, print_r($problems, true) . "===\n");
     require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';
     $oreon = $_SESSION['centreon'];
     $external_cmd = new CentreonExternalCommand($oreon);

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -173,13 +173,7 @@ if (
     $notify = 1;
 }
 
-$persistent = 0;
-if (
-    isset($centreon->optGen['monitoring_ack_persistent'])
-    && $centreon->optGen['monitoring_ack_persistent']
-) {
-    $persistent = 1;
-}
+$persistent = ! empty($centreon->optGen['monitoring_ack_persistent']) ? 1 : 0;
 
 try {
     $contact_infos = get_contact_information();

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -163,6 +163,30 @@ $selected = $rule->loadSelection(
     $get_information['form']['selection']
 );
 
+$sticky = 1;
+if (
+    isset($centreon->optGen['monitoring_ack_sticky'])
+    && $centreon->optGen['monitoring_ack_sticky']
+) {
+    $sticky = 2;
+}
+
+$notify = 0;
+if (
+    isset($centreon->optGen['monitoring_ack_notify'])
+    && $centreon->optGen['monitoring_ack_notify']
+) {
+    $notify = 1;
+}
+
+$persistent = 0;
+if (
+    isset($centreon->optGen['monitoring_ack_persistent'])
+    && $centreon->optGen['monitoring_ack_persistent']
+) {
+    $persistent = 1;
+}
+
 try {
     $contact_infos = get_contact_information();
     $resultat['result'] = $centreon_provider->submitTicket(
@@ -205,9 +229,9 @@ try {
                         sprintf(
                             $command,
                             $value['name'],
-                            2,
-                            0,
-                            1,
+                            $sticky,
+                            $notify,
+                            $persistent,
                             $contact_infos['alias'],
                             'open ticket: ' . $resultat['result']['ticket_id']
                         ),
@@ -240,9 +264,9 @@ try {
                             $command,
                             $value['host_name'],
                             $value['description'],
-                            2,
-                            0,
-                            1,
+                            $sticky,
+                            $notify,
+                            $persistent,
                             $contact_infos['alias'],
                             'open ticket: ' . $resultat['result']['ticket_id']
                         ),

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -165,13 +165,7 @@ $selected = $rule->loadSelection(
 
 $sticky = ! empty($centreon->optGen['monitoring_ack_sticky']) ? 2 : 1;
 
-$notify = 0;
-if (
-    isset($centreon->optGen['monitoring_ack_notify'])
-    && $centreon->optGen['monitoring_ack_notify']
-) {
-    $notify = 1;
-}
+$notify = ! empty($centreon->optGen['monitoring_ack_notify']) ? 1 : 0;
 
 $persistent = ! empty($centreon->optGen['monitoring_ack_persistent']) ? 1 : 0;
 

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -163,13 +163,7 @@ $selected = $rule->loadSelection(
     $get_information['form']['selection']
 );
 
-$sticky = 1;
-if (
-    isset($centreon->optGen['monitoring_ack_sticky'])
-    && $centreon->optGen['monitoring_ack_sticky']
-) {
-    $sticky = 2;
-}
+$sticky = ! empty($centreon->optGen['monitoring_ack_sticky']) ? 2 : 1;
 
 $notify = 0;
 if (


### PR DESCRIPTION
## Description

When opening a ticket, you have the possibility to create an ack. By default it is forced to sticky, no notification and persistent. Instead of using this, we should use the parameters that are set in administration -> monitoring.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

You can try to change following options:
![image](https://user-images.githubusercontent.com/9079781/158600574-53a27b39-9f18-4f3c-a1b6-3bb0c6bfd698.png)

Acknowledgement when we open tickets with open-tickets widget will follow above configuration.

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
