### PR TITLE
enh(provider): can use user name in smarty popup

### DIFF
--- a/widgets/open-tickets/src/action.php
+++ b/widgets/open-tickets/src/action.php
@@ -106,13 +106,14 @@ function format_popup()
 
     $result = $rule->getFormatPopupProvider(
         $preferences['rule'],
-        array(
+        [
             'title' => $title,
-            'user' => array(
+            'user' => [
+                'name' => $centreon->user->name,
                 'alias' => $centreon->user->alias,
                 'email' => $centreon->user->email
-            )
-        ),
+            ]
+        ],
         $widgetId,
         $uniq_id,
         $_REQUEST['cmd'],


### PR DESCRIPTION
## Description

You could use following variable in smarty fields:
```
{$user.name}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

You can use it in popup format. Example:
![image](https://user-images.githubusercontent.com/9079781/158620479-df1b98e9-e1f9-4943-ac24-1ee690afd80d.png)


## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
