### PR TITLE
enh(provider): add schedule check option

### DIFF
--- a/widgets/open-tickets/src/templates/acknowledge.ihtml
+++ b/widgets/open-tickets/src/templates/acknowledge.ihtml
@@ -33,10 +33,10 @@
                 <td class="FormRowValue"><input type='checkbox' name='processServices' {$process_service_checked}/></td>
             </tr>
             {/if}
-            <!--<tr>
+            <tr>
                 <td class="FormRowField">{$forceCheckLabel}</td>
                 <td class="FormRowValue"><input type='checkbox' name='forcecheck' {$force_active_checked}/></td>
-            </tr>-->
+            </tr>
         </table>
         <div id="validForm">
             <input type='hidden' name='selection' value='{$selection}' />

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -526,8 +526,8 @@ Output: {$service.output|substr:0:1024}
             $this->getFormValue('message_confirm') . '</textarea>';
         $ack_html = '<input type="checkbox" name="ack" value="yes" ' .
             ($this->getFormValue('ack') == 'yes' ? 'checked' : '') . '/>';
-        $schedule_check_html = '<input type="checkbox" name="schedule_check" value="yes" ' .
-            ($this->getFormValue('schedule_check') == 'yes' ? 'checked' : '') . '/>';
+        $scheduleCheckHtml = '<input type="checkbox" name="schedule_check" value="yes" ' .
+            ($this->getFormValue('schedule_check') === 'yes' ? 'checked' : '') . '/>';
         $close_ticket_enable_html = '<input type="checkbox" name="close_ticket_enable" value="yes" ' .
             ($this->getFormValue('close_ticket_enable') == 'yes' ? 'checked' : '') . '/>';
         $error_close_centreon_html = '<input type="checkbox" name="error_close_centreon" value="yes" ' .

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -229,6 +229,7 @@ abstract class AbstractProvider
     {
         $this->default_data['macro_ticket_id'] = 'TICKET_ID';
         $this->default_data['ack'] = 'yes';
+        $this->default_data['schedule_check'] = 'no';
 
         $this->default_data['format_popup'] = '
 <table class="table">
@@ -525,6 +526,8 @@ Output: {$service.output|substr:0:1024}
             $this->getFormValue('message_confirm') . '</textarea>';
         $ack_html = '<input type="checkbox" name="ack" value="yes" ' .
             ($this->getFormValue('ack') == 'yes' ? 'checked' : '') . '/>';
+        $schedule_check_html = '<input type="checkbox" name="schedule_check" value="yes" ' . 
+            ($this->getFormValue('schedule_check') == 'yes' ? 'checked' : '') . '/>';
         $close_ticket_enable_html = '<input type="checkbox" name="close_ticket_enable" value="yes" ' .
             ($this->getFormValue('close_ticket_enable') == 'yes' ? 'checked' : '') . '/>';
         $error_close_centreon_html = '<input type="checkbox" name="error_close_centreon" value="yes" ' .
@@ -534,6 +537,7 @@ Output: {$service.output|substr:0:1024}
             'url' => ['label' => _("Url"), 'html' => $url_html],
             'message_confirm' => ['label' => _("Confirm message popup"), 'html' => $message_confirm_html],
             'ack' => ['label' => _("Acknowledge"), 'html' => $ack_html],
+            'schedule_check' => ['label' => _("Schedule check"), 'html' => $schedule_check_html],
             'close_ticket_enable' => [
                 'label' => _("Enable"),
                 'enable' => $this->close_advanced,
@@ -746,6 +750,9 @@ Output: {$service.output|substr:0:1024}
         $this->save_config['simple']['ack'] = (
             isset($this->submitted_config['ack']) && $this->submitted_config['ack'] == 'yes'
         ) ? $this->submitted_config['ack'] : '';
+        $this->save_config['simple']['schedule_check'] = (
+            isset($this->submitted_config['schedule_check']) && $this->submitted_config['schedule_check'] == 'yes'
+        ) ? $this->submitted_config['schedule_check'] : '';
         $this->save_config['simple']['attach_files'] =
             (isset($this->submitted_config['attach_files']) && $this->submitted_config['attach_files'] == 'yes'
         ) ? $this->submitted_config['attach_files'] : '';
@@ -1050,6 +1057,15 @@ Output: {$service.output|substr:0:1024}
     public function doAck()
     {
         if (isset($this->rule_data['ack']) && $this->rule_data['ack'] == 'yes') {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    public function scheduleCheck()
+    {
+        if(isset($this->rule_data['schedule_check']) && $this->rule_data['schedule_check'] == 'yes') {
             return 1;
         }
 

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -1063,7 +1063,7 @@ Output: {$service.output|substr:0:1024}
         return 0;
     }
 
-    public function scheduleCheck()
+    public function doesScheduleCheck(): bool
     {
         return (
             isset($this->rule_data['schedule_check'])

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -537,7 +537,7 @@ Output: {$service.output|substr:0:1024}
             'url' => ['label' => _("Url"), 'html' => $url_html],
             'message_confirm' => ['label' => _("Confirm message popup"), 'html' => $message_confirm_html],
             'ack' => ['label' => _("Acknowledge"), 'html' => $ack_html],
-            'schedule_check' => ['label' => _("Schedule check"), 'html' => $schedule_check_html],
+            'schedule_check' => ['label' => _("Schedule check"), 'html' => $scheduleCheckHtml],
             'close_ticket_enable' => [
                 'label' => _("Enable"),
                 'enable' => $this->close_advanced,

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -526,7 +526,7 @@ Output: {$service.output|substr:0:1024}
             $this->getFormValue('message_confirm') . '</textarea>';
         $ack_html = '<input type="checkbox" name="ack" value="yes" ' .
             ($this->getFormValue('ack') == 'yes' ? 'checked' : '') . '/>';
-        $schedule_check_html = '<input type="checkbox" name="schedule_check" value="yes" ' . 
+        $schedule_check_html = '<input type="checkbox" name="schedule_check" value="yes" ' .
             ($this->getFormValue('schedule_check') == 'yes' ? 'checked' : '') . '/>';
         $close_ticket_enable_html = '<input type="checkbox" name="close_ticket_enable" value="yes" ' .
             ($this->getFormValue('close_ticket_enable') == 'yes' ? 'checked' : '') . '/>';
@@ -1065,7 +1065,7 @@ Output: {$service.output|substr:0:1024}
 
     public function scheduleCheck()
     {
-        if(isset($this->rule_data['schedule_check']) && $this->rule_data['schedule_check'] == 'yes') {
+        if (isset($this->rule_data['schedule_check']) && $this->rule_data['schedule_check'] == 'yes') {
             return 1;
         }
 

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -1063,6 +1063,11 @@ Output: {$service.output|substr:0:1024}
         return 0;
     }
 
+    /**
+     * Check if schedule check is needed
+     *
+     * @return bool
+     */
     public function doesScheduleCheck(): bool
     {
         return (

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -751,7 +751,7 @@ Output: {$service.output|substr:0:1024}
             isset($this->submitted_config['ack']) && $this->submitted_config['ack'] == 'yes'
         ) ? $this->submitted_config['ack'] : '';
         $this->save_config['simple']['schedule_check'] = (
-            isset($this->submitted_config['schedule_check']) && $this->submitted_config['schedule_check'] == 'yes'
+            isset($this->submitted_config['schedule_check']) && $this->submitted_config['schedule_check'] === 'yes'
         ) ? $this->submitted_config['schedule_check'] : '';
         $this->save_config['simple']['attach_files'] =
             (isset($this->submitted_config['attach_files']) && $this->submitted_config['attach_files'] == 'yes'

--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -1065,11 +1065,10 @@ Output: {$service.output|substr:0:1024}
 
     public function scheduleCheck()
     {
-        if (isset($this->rule_data['schedule_check']) && $this->rule_data['schedule_check'] == 'yes') {
-            return 1;
-        }
-
-        return 0;
+        return (
+            isset($this->rule_data['schedule_check'])
+            && $this->rule_data['schedule_check'] === 'yes'
+        );
     }
 
     public function doCloseTicket()

--- a/www/modules/centreon-open-tickets/providers/Abstract/templates/conf_container1main.ihtml
+++ b/www/modules/centreon-open-tickets/providers/Abstract/templates/conf_container1main.ihtml
@@ -29,13 +29,21 @@
 </tr>
 <tr class="list_two">
     <td class="FormRowField">
+        {$form.schedule_check.label}
+    </td>
+    <td class="FormRowValue">
+        {$form.schedule_check.html}
+    </td>
+</tr>
+<tr class="list_one">
+    <td class="FormRowField">
         {$form.grouplist.label}
     </td>
     <td class="FormRowValue">
         {include file="file:$centreon_open_tickets_path/providers/Abstract/templates/clone.ihtml" cloneId="groupList" cloneSet=$form.groupList}
     </td>
 </tr>
-<tr class="list_one">
+<tr class="list_two">
     <td class="FormRowField">
         {$form.customlist.label}
     </td>
@@ -43,7 +51,7 @@
         {include file="file:$centreon_open_tickets_path/providers/Abstract/templates/clone.ihtml" cloneId="customList" cloneSet=$form.customList}
     </td>
 </tr>
-<tr class="list_two">
+<tr class="list_one">
     <td class="FormRowField">
         {$form.bodylist.label}
     </td>

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -103,7 +103,7 @@ if (isset($get_information['form']['notify'])) {
     $notify = 1;
 }
 if (isset($get_information['form']['forcecheck'])) {
-    $forceCheck = 1;
+    $forceCheck = true;
 }
 
 try {

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -170,7 +170,7 @@ try {
             ]
         );
         if ($forceCheck) {
-            $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%s";
+            $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%d";
             call_user_func_array(
                 [$external_cmd, $method_external_name],
                 [

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -19,24 +19,24 @@
  * limitations under the License.
  */
 
-$resultat = array(
+$resultat = [
     "code" => 0,
-    "msg" => 'ok',
-);
+    "msg" => 'ok'
+];
 
 // We get Host or Service
 $selected_values = explode(',', $get_information['form']['selection']);
 $db_storage = new centreonDBManager('centstorage');
 
-$problems = array();
+$problems = [];
 
 # check services and hosts
 $selected_str = '';
 $selected_str_append = '';
 $hosts_selected_str = '';
 $hosts_selected_str_append = '';
-$hosts_done = array();
-$services_done = array();
+$hosts_done = [];
+$services_done = [];
 foreach ($selected_values as $value) {
     $str = explode(';', $value);
     $selected_str .= $selected_str_append . 'services.host_id = ' . $str[0] . ' AND services.service_id = ' . $str[1];
@@ -92,6 +92,7 @@ while (($row = $dbResult->fetch())) {
 $persistent = 0;
 $sticky = 0;
 $notify = 0;
+$forceCheck = 0;
 if (isset($get_information['form']['persistent'])) {
     $persistent = 1;
 }
@@ -100,6 +101,9 @@ if (isset($get_information['form']['sticky'])) {
 }
 if (isset($get_information['form']['notify'])) {
     $notify = 1;
+}
+if (isset($get_information['form']['forcecheck'])) {
+    $forceCheck = 1;
 }
 
 try {
@@ -117,8 +121,8 @@ try {
         if (is_null($row['description']) || $row['description'] == '') {
             $command = "ACKNOWLEDGE_HOST_PROBLEM;%s;%s;%s;%s;%s;%s";
             call_user_func_array(
-                array($external_cmd, $method_external_name),
-                array(
+                [$external_cmd, $method_external_name],
+                [
                     sprintf(
                         $command,
                         $row['host_name'],
@@ -129,15 +133,29 @@ try {
                         $get_information['form']['comment']
                     ),
                     $row['instance_id']
-                )
+                ]
             );
+            if ($forceCheck == 1) {
+                $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%s";
+                call_user_func_array(
+                    [$external_cmd, $method_external_name],
+                    [
+                        sprintf(
+                            $command,
+                            $row['host_name'],
+                            time()
+                        ),
+                        $row['instance_id']
+                    ]
+                );
+            }
             continue;
         }
 
         $command = "ACKNOWLEDGE_SVC_PROBLEM;%s;%s;%s;%s;%s;%s;%s";
         call_user_func_array(
-            array($external_cmd, $method_external_name),
-            array(
+            [$external_cmd, $method_external_name],
+            [
                 sprintf(
                     $command,
                     $row['host_name'],
@@ -149,8 +167,23 @@ try {
                     $get_information['form']['comment']
                 ),
                 $row['instance_id']
-            )
+            ]
         );
+        if ($forceCheck == 1) {
+            $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%s";
+            call_user_func_array(
+                [$external_cmd, $method_external_name],
+                [
+                    sprintf(
+                        $command,
+                        $row['host_name'],
+                        $row['description'],
+                        time()
+                    ),
+                    $row['instance_id']
+                ]
+            );
+        }
     }
 
     $external_cmd->write();

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -21,7 +21,7 @@
 
 $resultat = [
     "code" => 0,
-    "msg" => 'ok'
+    "msg" => 'ok',
 ];
 
 // We get Host or Service

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -135,7 +135,7 @@ try {
                     $row['instance_id']
                 ]
             );
-            if ($forceCheck == 1) {
+            if ($forceCheck) {
                 $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%s";
                 call_user_func_array(
                     [$external_cmd, $method_external_name],

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -136,7 +136,7 @@ try {
                 ]
             );
             if ($forceCheck) {
-                $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%s";
+                $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%d";
                 call_user_func_array(
                     [$external_cmd, $method_external_name],
                     [

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -92,7 +92,7 @@ while (($row = $dbResult->fetch())) {
 $persistent = 0;
 $sticky = 0;
 $notify = 0;
-$forceCheck = 0;
+$forceCheck = false;
 if (isset($get_information['form']['persistent'])) {
     $persistent = 1;
 }

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/serviceAck.php
@@ -169,7 +169,7 @@ try {
                 $row['instance_id']
             ]
         );
-        if ($forceCheck == 1) {
+        if ($forceCheck) {
             $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%s";
             call_user_func_array(
                 [$external_cmd, $method_external_name],

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -271,7 +271,7 @@ try {
                 );
             }
             if ($centreon_provider->doesScheduleCheck()) {
-                $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%s";
+                $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%d";
                 call_user_func_array(
                     [$external_cmd, $method_external_name],
                     [

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -221,7 +221,7 @@ try {
                     ]
                 );
             }
-            if ($centreon_provider->scheduleCheck()) {
+            if ($centreon_provider->doesScheduleCheck()) {
                 $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%s";
                 call_user_func_array(
                     [$external_cmd, $method_external_name],

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -192,8 +192,8 @@ try {
         foreach ($selected['host_selected'] as $value) {
             $command = "CHANGE_CUSTOM_HOST_VAR;%s;%s;%s";
             call_user_func_array(
-                array($external_cmd, $method_external_name),
-                array(
+                [$external_cmd, $method_external_name],
+                [
                     sprintf(
                         $command,
                         $value['name'],
@@ -201,13 +201,13 @@ try {
                         $resultat['result']['ticket_id']
                     ),
                     $value['instance_id']
-                )
+                ]
             );
             if ($centreon_provider->doAck()) {
                 $command = "ACKNOWLEDGE_HOST_PROBLEM;%s;%s;%s;%s;%s;%s";
                 call_user_func_array(
-                    array($external_cmd, $method_external_name),
-                    array(
+                    [$external_cmd, $method_external_name],
+                    [
                         sprintf(
                             $command,
                             $value['name'],
@@ -218,15 +218,29 @@ try {
                             'open ticket: ' . $resultat['result']['ticket_id']
                         ),
                         $value['instance_id']
-                    )
+                    ]
+                );
+            }
+            if ($centreon_provider->scheduleCheck()) {
+                $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%s";
+                call_user_func_array(
+                    [$external_cmd, $method_external_name],
+                    [
+                        sprintf(
+                            $command,
+                            $value['name'],
+                            time()
+                        ),
+                        $value['instance_id']
+                    ]
                 );
             }
         }
         foreach ($selected['service_selected'] as $value) {
             $command = "CHANGE_CUSTOM_SVC_VAR;%s;%s;%s;%s";
             call_user_func_array(
-                array($external_cmd, $method_external_name),
-                array(
+                [$external_cmd, $method_external_name],
+                [
                     sprintf(
                         $command,
                         $value['host_name'],
@@ -235,13 +249,13 @@ try {
                         $resultat['result']['ticket_id']
                     ),
                     $value['instance_id']
-                )
+                ]
             );
             if ($centreon_provider->doAck()) {
                 $command = "ACKNOWLEDGE_SVC_PROBLEM;%s;%s;%s;%s;%s;%s;%s";
                 call_user_func_array(
-                    array($external_cmd, $method_external_name),
-                    array(
+                    [$external_cmd, $method_external_name],
+                    [
                         sprintf(
                             $command,
                             $value['host_name'],
@@ -253,7 +267,22 @@ try {
                             'open ticket: ' . $resultat['result']['ticket_id']
                         ),
                         $value['instance_id']
-                    )
+                    ]
+                );
+            }
+            if ($centreon_provider->scheduleCheck()) {
+                $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%s";
+                call_user_func_array(
+                    [$external_cmd, $method_external_name],
+                    [
+                        sprintf(
+                            $command,
+                            $value['host_name'],
+                            $value['description'],
+                            time()
+                        ),
+                        $value['instance_id']
+                    ]
                 );
             }
         }

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -222,7 +222,7 @@ try {
                 );
             }
             if ($centreon_provider->doesScheduleCheck()) {
-                $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%s";
+                $command = "SCHEDULE_FORCED_HOST_CHECK;%s;%d";
                 call_user_func_array(
                     [$external_cmd, $method_external_name],
                     [

--- a/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -270,7 +270,7 @@ try {
                     ]
                 );
             }
-            if ($centreon_provider->scheduleCheck()) {
+            if ($centreon_provider->doesScheduleCheck()) {
                 $command = "SCHEDULE_FORCED_SVC_CHECK;%s;%s;%s";
                 call_user_func_array(
                     [$external_cmd, $method_external_name],


### PR DESCRIPTION
## Description

Add an option in the rule to schedule the check. Useful with DSM passive service (you only want to open a ticket and the service goes back to OK).

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [X] 21.10.x
- [X] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Activate the checkbox on your rule:
![image](https://user-images.githubusercontent.com/9079781/158771684-1b5846fe-a7e9-47eb-88ab-81f274b34bd2.png)

When you open a ticket for a service, you should have following lines in centengine.log:
```
[1647506666] [846] EXTERNAL COMMAND: CHANGE_CUSTOM_SVC_VAR;test-vtom3;Jobs;TICKET_ID;23
[1647506666] [846] EXTERNAL COMMAND: ACKNOWLEDGE_SVC_PROBLEM;test-vtom3;Jobs;2;0;1;admin;open ticket: 23
[1647506666] [846] EXTERNAL COMMAND: SCHEDULE_FORCED_SVC_CHECK;test-vtom3;Jobs;1647506664
```

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
