### PR TITLE
fix stream_select method

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -1277,7 +1277,9 @@ Output: {$service.output|substr:0:1024}
         do {
             $timeleft = $timeout - time();
             $read = array($pipes[1]);
-            stream_select($read, $write = null, $exeptions = null, $timeleft, null);
+            $write = null;
+            $exceptions = null;
+            stream_select($read, $write, $exceptions, $timeleft, null);
 
             if (!empty($read)) {
                 $output .= fread($pipes[1], 8192);


### PR DESCRIPTION
## Description

according to php documentation, the stream_select() method needs the read, write and except variables to be passed by reference 
(see https://www.php.net/manual/en/function.stream-select.php)
therefore, we can't set them inside the method call or you'll get the following error : 

`stream_select(): Argument #2 ($write) cannot be passed by reference.`

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

to test this, create an open ticket rule, add a command that will run a simple bash script like 

![image](https://user-images.githubusercontent.com/7352865/159675229-93ca5888-8ddd-4c12-ba7c-86f563ea1e4d.png)


``` bash
#!/bin/bash
exit 0
```

Make sure that the script is runnable by the apache user. 

try to open a ticket using this rule and when submitting the ticket you'll have an infinite loading screen. 

Apply this fix and the infinite loading screen should not be infinite.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
