### PR TITLE
fix fatal error when $group is not an array

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
+++ b/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
@@ -10,7 +10,7 @@
             {assign var="group" value=$sortgroup_result}
         {/if}
         <select id="select_{$groupId}" name="select_{$groupId}">
-        {if $group|@count != 1}
+        {if $group|is_array && $group|@count != 1}
             <option value="-1"> -- select -- </option>
         {/if}
         {foreach from=$group key=k item=v}


### PR DESCRIPTION
## Description

when you try to open a ticket using the itop provider, nothing will happen and you'll have a fatal error in your centreon-error.log 

````
Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, string given in /usr/share/centreon/GPL_LIB/SmartyCache/compile/fdf91122f2894e9f67b971588eee542ebcb59e37_0.file.group.ihtml.php:41
````

the reason is that the itop provider have dynamic lists that are displayed.  The $group variable for those lists will only be set when other lists have a selected value.

Maybe we could also change the itop provider to be compatible with that but it would be a lot more work that is not relevent to me. And anyway, having a more reliable smarty is good.

And we've created this issue when doing https://github.com/centreon/centreon-open-tickets/commit/5f17e24afa4690ef43132dc90b947b58ebb0a795 so it is better to handle it right from the smarty file

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

without the patch 

- use the itop provider
- try to open a ticket
- the popup will never work and you'll have a fatal error in your centreon-error.log

with the patch

- the popup will work fine

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
