### PR TITLE
MON-13067-install-remove-default-value-for-colors-in-options-table-centreon-open-tickets

### DIFF
--- a/widgets/open-tickets/src/export.php
+++ b/widgets/open-tickets/src/export.php
@@ -66,7 +66,7 @@ $widgetObj = new CentreonWidget($centreon, $db);
 $preferences = $widgetObj->getWidgetPreferences($widgetId);
 
 // Set Colors Table
-$res = $db->query("SELECT `key`, `value` FROM `options` WHERE `key` LIKE 'color%'");
+
 $stateSColors = array(
     0 => "#13EB3A",
     1 => "#F8C706",
@@ -80,25 +80,7 @@ $stateHColors = array(
     2 => "#DCDADA",
     3 => "#2AD1D4"
 );
-while ($row = $res->fetch()) {
-    if ($row['key'] == "color_ok") {
-        $stateSColors[0] = $row['value'];
-    } elseif ($row['key'] == "color_warning") {
-        $stateSColors[1] = $row['value'];
-    } elseif ($row['key'] == "color_critical") {
-        $stateSColors[2] = $row['value'];
-    } elseif ($row['key'] == "color_unknown") {
-        $stateSColors[3] = $row['value'];
-    } elseif ($row['key'] == "color_pending") {
-        $stateSColors[4] = $row['value'];
-    } elseif ($row['key'] == "color_up") {
-        $stateHColors[4] = $row['value'];
-    } elseif ($row['key'] == "color_down") {
-        $stateHColors[4] = $row['value'];
-    } elseif ($row['key'] == "color_unreachable") {
-        $stateHColors[4] = $row['value'];
-    }
-}
+
 
 $stateLabels = array(
     0 => "Ok",

--- a/widgets/open-tickets/src/index.php
+++ b/widgets/open-tickets/src/index.php
@@ -76,43 +76,22 @@ if (!isset($preferences['rule'])) {
 
 $macro_tickets = $rule->getMacroNames($preferences['rule'], $widgetId);
 
-// Set Colors Table
-$res = $db->query("SELECT `key`, `value` FROM `options` WHERE `key` LIKE 'color%'");
-$stateSColors = array(
-    0 => "#13EB3A",
-    1 => "#F8C706",
-    2 => "#F91D05",
-    3 => "#DCDADA",
-    4 => "#2AD1D4"
-);
-$stateHColors = array(
-    0 => "#13EB3A",
-    1 => "#F91D05",
-    2 => "#DCDADA",
-    3 => "#2AD1D4"
-);
-while ($row = $res->fetch()) {
-    if ($row['key'] == "color_ok") {
-        $stateSColors[0] = $row['value'];
-    } elseif ($row['key'] == "color_warning") {
-        $stateSColors[1] = $row['value'];
-    } elseif ($row['key'] == "color_critical") {
-        $stateSColors[2] = $row['value'];
-    } elseif ($row['key'] == "color_unknown") {
-        $stateSColors[3] = $row['value'];
-    } elseif ($row['key'] == "color_pending") {
-        $stateSColors[4] = $row['value'];
-    } elseif ($row['key'] == "color_up") {
-        $stateHColors[4] = $row['value'];
-    } elseif ($row['key'] == "color_down") {
-        $stateHColors[4] = $row['value'];
-    } elseif ($row['key'] == "color_unreachable") {
-        $stateHColors[4] = $row['value'];
-    }
-}
 
 $aStateType = array("1" => "H", "0" => "S");
+$aColorHost = array(
+    0 => 'host_up',
+    1 => 'host_down',
+    2 => 'host_unreachable',
+    4 => 'host_pending'
+);
 
+$aColorService = array(
+    0 => 'service_ok',
+    1 => 'service_warning',
+    2 => 'service_critical',
+    3 => 'service_unknown',
+    4 => 'pending'
+);
 $stateLabels = array(
     0 => "Ok",
     1 => "Warning",
@@ -429,10 +408,10 @@ while ($row = $res->fetch()) {
         } elseif ($key == "check_attempt") {
             $value = $value . "/" . $row['max_check_attempts'] . ' (' . $aStateType[$row['state_type']] . ')';
         } elseif ($key == "s_state") {
-            $data[$row['host_id'] . "_" . $row['service_id']]['color'] = $stateSColors[$value];
+            $data[$row['host_id'] . "_" . $row['service_id']]['color'] = $aColorService[$value];
             $value = $stateLabels[$value];
         } elseif ($key == "h_state") {
-            $data[$row['host_id'] . "_" . $row['service_id']]['hcolor'] = $stateHColors[$value];
+            $data[$row['host_id'] . "_" . $row['service_id']]['hcolor'] = $aColorHost[$value];
             $value = $stateLabels[$value];
         } elseif ($key == "output") {
             $value = substr($value, 0, $outputLength);

--- a/widgets/open-tickets/src/index.php
+++ b/widgets/open-tickets/src/index.php
@@ -78,12 +78,12 @@ $macro_tickets = $rule->getMacroNames($preferences['rule'], $widgetId);
 
 
 $aStateType = array("1" => "H", "0" => "S");
-$aColorHost = array(
+$aColorHost = [
     0 => 'host_up',
     1 => 'host_down',
     2 => 'host_unreachable',
     4 => 'host_pending'
-);
+];
 
 $aColorService = array(
     0 => 'service_ok',

--- a/widgets/open-tickets/src/index.php
+++ b/widgets/open-tickets/src/index.php
@@ -85,13 +85,13 @@ $aColorHost = [
     4 => 'host_pending'
 ];
 
-$aColorService = array(
+$aColorService = [
     0 => 'service_ok',
     1 => 'service_warning',
     2 => 'service_critical',
     3 => 'service_unknown',
     4 => 'pending'
-);
+];
 $stateLabels = array(
     0 => "Ok",
     1 => "Warning",

--- a/widgets/open-tickets/src/templates/table.ihtml
+++ b/widgets/open-tickets/src/templates/table.ihtml
@@ -106,7 +106,7 @@
             {/if}
         {if $preferences.display_status}
         <td class='ListColCenter' style='white-space:nowrap;'>
-            <span  style='font-weight:bold;' class="badge {$elem.color}">{$elem.s_state}</span>
+            <span style='font-weight:bold;' class="badge {$elem.color}">{$elem.s_state}</span>
         </td>
         {/if}
         {if $preferences.display_duration}<td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>{/if}

--- a/widgets/open-tickets/src/templates/table.ihtml
+++ b/widgets/open-tickets/src/templates/table.ihtml
@@ -48,7 +48,7 @@
                         {if $elem.icon_image != ''}
                             <img src ='../../img/media/{$elem.icon_image}' width='16' height='16' style ='padding-right:5px;' />
                         {/if}
-                        <span class="state_badge" style='background-color: {$elem.hcolor};'></span>
+                        <span class="state_badge {$elem.hcolor}"></span>
                         <a href='../../main.php?p=20202&o=hd&host_name={$elem.encoded_hostname}' target=_blank>{$elem.hostname}</a>
                     </td>
                     <td class='ListColRight'>
@@ -77,7 +77,7 @@
         {if $preferences.display_svc_description}
             <td class=''>
                 {if $preferences.display_status == 0}
-                    <div style='background-color: {$elem.color};'>
+                    <div class="{$elem.color}">
                 {/if}
         <a href='../../main.php?p=202&o=svcd&host_name={$elem.encoded_hostname}&service_description={$elem.encoded_description}' target=_blank>{$elem.description}</a>
         {if $preferences.display_status == 0}
@@ -106,7 +106,7 @@
             {/if}
         {if $preferences.display_status}
         <td class='ListColCenter' style='white-space:nowrap;'>
-            <span style='background-color: {$elem.color};font-weight:bold;' class="badge">{$elem.s_state}</span>
+            <span  style='font-weight:bold;' class="badge {$elem.color}">{$elem.s_state}</span>
         </td>
         {/if}
         {if $preferences.display_duration}<td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>{/if}


### PR DESCRIPTION
## Description
 on a fresh install, we insert values for colors in database. (in options table). Those values seems not used anymore and should be removed.

[centreon/insertBaseConf.sql at develop · centreon/centreon](https://github.com/centreon/centreon/blob/develop/www/install/insertBaseConf.sql#L91-L103) 

Technical Information

All widgets must use CSS colors definition instead of database

Legacy monitoring pages must use CSS colors definition too

Use this query to find widgets: https://github.com/search?q=org%3Acentreon+color_ok&type=code -

**Fixes** # MON-13067

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>
Install a new Centreon central server
 
Install widgets and check that colors are ok

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
