### PR TITLE
fix(itop): check group variable type to avoid fatal error (#242)

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
+++ b/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
@@ -10,7 +10,7 @@
             {assign var="group" value=$sortgroup_result}
         {/if}
         <select id="select_{$groupId}" name="select_{$groupId}">
-        {if $group|@count != 1}
+        {if $group|is_array && $group|@count != 1}
             <option value="-1"> -- select -- </option>
         {/if}
         {foreach from=$group key=k item=v}


### PR DESCRIPTION
## Description

check group variable type to avoid fatal error

**Fixes** MON-14551

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)