### PR TITLE
fix itop ticket url

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Itop/ItopProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Itop/ItopProvider.class.php
@@ -114,7 +114,7 @@ class ItopProvider extends AbstractProvider
     {
         parent::setDefaultValueMain($body_html = 0);
 
-        $this->default_data['url'] = '{$protocol}://{$address}/webservices/rest.php?version={$version}';
+        $this->default_data['url'] = '{$protocol}://{$address}/pages/UI.php?operation=details&class=UserRequest&id={$ticket_id}';
 
         $this->default_data['format_popup'] = '
 <table class="table">

--- a/www/modules/centreon-open-tickets/providers/Itop/ItopProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Itop/ItopProvider.class.php
@@ -114,7 +114,8 @@ class ItopProvider extends AbstractProvider
     {
         parent::setDefaultValueMain($body_html = 0);
 
-        $this->default_data['url'] = '{$protocol}://{$address}/pages/UI.php?operation=details&class=UserRequest&id={$ticket_id}';
+        $this->default_data['url'] = '{$protocol}://{$address}/pages/UI.php?operation=details'
+            . '&class=UserRequest&id={$ticket_id}';
 
         $this->default_data['format_popup'] = '
 <table class="table">


### PR DESCRIPTION
## Description

with this patch, you'll be redirect to the right url when clicking the ticket id in the open ticket widget


closes https://github.com/centreon/centreon-open-tickets/pull/121

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

have a working itop
create a new itop provider rule in centreon
open a ticket from the open ticket widget
in the open ticket widget where you see your opened tickets, click the ticket ID and you'll be sent to the ticket form inside itop

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
