### PR TITLE
fix stream select method 22.04.x

### DIFF
--- a/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -1310,7 +1310,9 @@ Output: {$service.output|substr:0:1024}
         do {
             $timeleft = $timeout - time();
             $read = array($pipes[1]);
-            stream_select($read, $write = null, $exeptions = null, $timeleft, null);
+            $write = null;
+            $exceptions = null;
+            stream_select($read, $write, $exceptions, $timeleft, null);
 
             if (!empty($read)) {
                 $output .= fread($pipes[1], 8192);


### PR DESCRIPTION
## Description

fix an issue that breaks the "execute command" feature of an open ticket rule

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

have an open ticket rule, 
configure the execute command parameter of your rule
open a ticket (with the patch, it will work, without, it won't)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
